### PR TITLE
Improve the speed and amount of concurrent downloads at package installs

### DIFF
--- a/commands/install/fetchAllDependencies.js
+++ b/commands/install/fetchAllDependencies.js
@@ -22,15 +22,17 @@ export async function fetchAllDependencies(
     packageInfoList.push({ ...packageInfo, version: "latest" });
 
     if (packageInfo.dependencies) {
-      for (const subDepName in packageInfo.dependencies) {
-        await fetchAllDependencies(
-          subDepName,
-          spinner,
-          packageInfoList,
-          packages,
-          installDir,
-        );
-      }
+      await Promise.all(
+        Object.keys(packageInfo.dependencies).map((subDepName) =>
+          fetchAllDependencies(
+            subDepName,
+            spinner,
+            packageInfoList,
+            packages,
+            installDir,
+          ),
+        ),
+      );
     }
 
     const depInstallDir = join(installDir, "node_modules");

--- a/commands/install/index.js
+++ b/commands/install/index.js
@@ -85,49 +85,56 @@ export async function install(args) {
     const isDevDependency = flags.includes("--dev") || flags.includes("-D");
     const isForce = flags.includes("--force") || flags.includes("-f");
 
-    const packageInfoList = [];
-    for (const pkg of packages) {
-      let packageName, version;
+    const packageInfoList = await Promise.all(
+      packages.map(async (pkg) => {
+        let packageName, version;
 
-      if (pkg.startsWith("@")) {
-        const atIndex = pkg.indexOf("@", 1);
-        if (atIndex === -1) {
-          packageName = pkg;
-          version = "latest";
+        if (pkg.startsWith("@")) {
+          const atIndex = pkg.indexOf("@", 1);
+          if (atIndex === -1) {
+            packageName = pkg;
+            version = "latest";
+          } else {
+            packageName = pkg.substring(0, atIndex);
+            version = pkg.substring(atIndex + 1) || "latest";
+          }
         } else {
-          packageName = pkg.substring(0, atIndex);
-          version = pkg.substring(atIndex + 1) || "latest";
+          [packageName, version] = pkg.split("@");
+          version = version || "latest";
         }
-      } else {
-        [packageName, version] = pkg.split("@");
-        version = version || "latest";
-      }
 
-      const packageInfo = await fetchPackageMetadata(
-        packageName,
-        spinner,
-        packageInfoList.length + 1,
-        packages.length,
-      );
+        const packageInfo = await fetchPackageMetadata(
+          packageName,
+          spinner,
+          packageInfoList.length + 1,
+          packages.length,
+        );
 
-      if (version === "latest") {
-        version = packageInfo["dist-tags"].latest;
-      }
+        if (version === "latest") {
+          version = packageInfo["dist-tags"].latest;
+        }
 
-      packageInfoList.push({ ...packageInfo, version });
+        return { ...packageInfo, version };
+      }),
+    );
 
-      if (packageInfo.dependencies) {
-        for (const depName in packageInfo.dependencies) {
-          await fetchAllDependencies(
-            depName,
-            spinner,
-            packageInfoList,
-            packages,
-            installDir,
+    await Promise.all(
+      packageInfoList.map(async (packageInfo) => {
+        if (packageInfo.dependencies) {
+          await Promise.all(
+            Object.keys(packageInfo.dependencies).map((depName) =>
+              fetchAllDependencies(
+                depName,
+                spinner,
+                packageInfoList,
+                packages,
+                installDir,
+              ),
+            ),
           );
         }
-      }
-    }
+      }),
+    );
 
     const calculateTotalDependencies = (
       pkgInfo,

--- a/utils/fetchPackageMetadata.js
+++ b/utils/fetchPackageMetadata.js
@@ -3,18 +3,24 @@ import { retryOnECONNRESET } from "./retry.js";
 import chalk from "chalk";
 
 export async function fetchPackageMetadata(
-  packageName,
+  packageNames,
   spinner,
   currentPackageIndex,
   totalPackages,
   isForce,
 ) {
-  spinner.text = `${isForce ? chalk.bgYellow("FORCE") : ""} [${currentPackageIndex}/${totalPackages}] Fetching metadata for ${packageName}`;
-  return retryOnECONNRESET(async (packageName) => {
+  spinner.text = `${isForce ? chalk.bgYellow("FORCE") : ""} [${currentPackageIndex}/${totalPackages}] Fetching metadata for packages: ${packageNames.join(", ")}`;
+  const fetchMetadata = async (packageName) => {
     const response = await fetch(`https://registry.npmjs.org/${packageName}`);
     if (!response.ok) {
       throw new Error(`Failed to fetch metadata for package ${packageName}`);
     }
     return response.json();
-  }, packageName);
+  };
+
+  const metadataPromises = packageNames.map((packageName) =>
+    retryOnECONNRESET(fetchMetadata, packageName),
+  );
+
+  return Promise.all(metadataPromises);
 }


### PR DESCRIPTION
Improve the speed and amount of concurrent downloads during package installs.

* Refactor `commands/install/index.js` to use `Promise.all` for concurrent fetching and installation of packages and dependencies.
* Update `commands/install/fetchAllDependencies.js` to handle concurrent downloads of dependencies using `Promise.all`.
* Modify `utils/fetchPackageMetadata.js` to fetch package metadata concurrently by accepting an array of package names and using `Promise.all`.

