### PR TITLE
Fix ReferenceError for 'packageInfoList' before initialization

### DIFF
--- a/commands/install/index.js
+++ b/commands/install/index.js
@@ -10,6 +10,8 @@ import chalk from "chalk";
 import logger from "../../lib/logger.js";
 import { fetchAllDependencies } from "./fetchAllDependencies.js";
 
+const packageInfoList = [];
+
 export async function install(args) {
   const packages = [];
   const flags = [];
@@ -85,7 +87,7 @@ export async function install(args) {
     const isDevDependency = flags.includes("--dev") || flags.includes("-D");
     const isForce = flags.includes("--force") || flags.includes("-f");
 
-    const packageInfoList = await Promise.all(
+    await Promise.all(
       packages.map(async (pkg) => {
         let packageName, version;
 


### PR DESCRIPTION
Fix the ReferenceError for 'packageInfoList' before initialization in `commands/install/index.js`.

* Declare and initialize `packageInfoList` as an empty array at line 18.
* Remove the declaration of `packageInfoList` inside the `install` function and use the already initialized `packageInfoList`.

