### PR TITLE
Fix TypeError in fetchPackageMetadata function

### DIFF
--- a/utils/fetchPackageMetadata.js
+++ b/utils/fetchPackageMetadata.js
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { retryOnECONNRESET } from "./retry.js";
 import chalk from "chalk";
+import logger from "../lib/logger.js";
 
 export async function fetchPackageMetadata(
   packageNames,
@@ -9,6 +10,14 @@ export async function fetchPackageMetadata(
   totalPackages,
   isForce,
 ) {
+  if (!Array.isArray(packageNames)) {
+    logger.logError({
+      message: "packageNames should be an array",
+      exit: true,
+      errorType: " PACM_ERROR ",
+    });
+  }
+
   spinner.text = `${isForce ? chalk.bgYellow("FORCE") : ""} [${currentPackageIndex}/${totalPackages}] Fetching metadata for packages: ${packageNames.join(", ")}`;
   const fetchMetadata = async (packageName) => {
     const response = await fetch(`https://registry.npmjs.org/${packageName}`);


### PR DESCRIPTION
Add type checking to `fetchPackageMetadata` function to handle TypeError caused by `packageNames.join` not being a function.

* Import `logger` from `../lib/logger.js`.
* Add a check to ensure `packageNames` is an array before calling `join`.
* Log an error and exit gracefully if `packageNames` is not an array.

