### PR TITLE
Fix fetch package metadata function usage in install command

### DIFF
--- a/utils/fetchPackageMetadata.js
+++ b/utils/fetchPackageMetadata.js
@@ -3,13 +3,13 @@ import { retryOnECONNRESET } from "./retry.js";
 import chalk from "chalk";
 
 export async function fetchPackageMetadata(
-  packageNames,
+  packageName,
   spinner,
   currentPackageIndex,
   totalPackages,
   isForce,
 ) {
-  spinner.text = `${isForce ? chalk.bgYellow("FORCE") : ""} [${currentPackageIndex}/${totalPackages}] Fetching metadata for packages: ${packageNames.join(", ")}`;
+  spinner.text = `${isForce ? chalk.bgYellow("FORCE") : ""} [${currentPackageIndex}/${totalPackages}] Fetching metadata for package: ${packageName}`;
   const fetchMetadata = async (packageName) => {
     const response = await fetch(`https://registry.npmjs.org/${packageName}`);
     if (!response.ok) {
@@ -18,9 +18,5 @@ export async function fetchPackageMetadata(
     return response.json();
   };
 
-  const metadataPromises = packageNames.map((packageName) =>
-    retryOnECONNRESET(fetchMetadata, packageName),
-  );
-
-  return Promise.all(metadataPromises);
+  return retryOnECONNRESET(fetchMetadata, packageName);
 }


### PR DESCRIPTION
Fix the issue with `fetchPackageMetadata` function in `commands/install/index.js` by passing a single package name instead of an array.

* Modify `fetchPackageMetadata` function in `utils/fetchPackageMetadata.js` to accept a single package name.
* Update the `spinner.text` to reflect fetching metadata for a single package.
* Remove the mapping of package names to metadata promises and return a single promise for the package metadata.

