### PR TITLE
Implement peer dependencies in install command

### DIFF
--- a/commands/install/fetchPackageMetadata.js
+++ b/commands/install/fetchPackageMetadata.js
@@ -23,6 +23,12 @@ export async function fetchPackageMetadata(
       });
     }
     const metadata = await response.json();
+
+    // Handle peer dependencies in the metadata
+    if (metadata.peerDependencies) {
+      metadata.peerDependencies = metadata.peerDependencies;
+    }
+
     return metadata;
   } catch (error) {
     spinner.fail(

--- a/commands/install/index.js
+++ b/commands/install/index.js
@@ -27,12 +27,12 @@ export async function install(args) {
   const packageJsonPath = join(installDir, "package.json");
   const lockFilePath = join(installDir, "pacm.lockp");
   let packageJson = {};
-  let lockFileData = { dependencies: {}, devDependencies: {} };
+  let lockFileData = { dependencies: {}, devDependencies: {}, peerDependencies: {} };
 
   if (existsSync(packageJsonPath)) {
     packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
   } else {
-    packageJson = { dependencies: {}, devDependencies: {} };
+    packageJson = { dependencies: {}, devDependencies: {}, peerDependencies: {} };
   }
 
   if (!packageJson.dependencies) {
@@ -43,6 +43,10 @@ export async function install(args) {
     packageJson.devDependencies = {};
   }
 
+  if (!packageJson.peerDependencies) {
+    packageJson.peerDependencies = {};
+  }
+
   if (existsSync(lockFilePath)) {
     if (
       readFileSync(lockFilePath, "utf-8") === "" ||
@@ -50,7 +54,7 @@ export async function install(args) {
       readFileSync(lockFilePath, "utf-8") === "{\n}" ||
       readFileSync(lockFilePath, "utf-8") === "{\n}\n"
     ) {
-      lockFileData = { dependencies: {}, devDependencies: {} };
+      lockFileData = { dependencies: {}, devDependencies: {}, peerDependencies: {} };
     } else {
       lockFileData = JSON.parse(readFileSync(lockFilePath, "utf-8"));
     }
@@ -64,10 +68,12 @@ export async function install(args) {
       if (existsSync(packageJsonPath)) {
         packages.push(...Object.keys(packageJson.dependencies));
         packages.push(...Object.keys(packageJson.devDependencies));
+        packages.push(...Object.keys(packageJson.peerDependencies));
       } else if (existsSync(lockFilePath)) {
         const allDependencies = {
           ...lockFileData.dependencies,
           ...lockFileData.devDependencies,
+          ...lockFileData.peerDependencies,
         };
         const nonDependencyPackages = Object.keys(allDependencies).filter(
           (pkg) => {
@@ -127,6 +133,18 @@ export async function install(args) {
           );
         }
       }
+
+      if (packageInfo.peerDependencies) {
+        for (const peerDepName in packageInfo.peerDependencies) {
+          await fetchAllDependencies(
+            peerDepName,
+            spinner,
+            packageInfoList,
+            packages,
+            installDir,
+          );
+        }
+      }
     }
 
     const calculateTotalDependencies = (
@@ -138,7 +156,8 @@ export async function install(args) {
       visited.add(pkgInfo.name);
 
       const dependencies = pkgInfo.versions[version].dependencies || {};
-      let totalDependencies = Object.keys(dependencies).length;
+      const peerDependencies = pkgInfo.versions[version].peerDependencies || {};
+      let totalDependencies = Object.keys(dependencies).length + Object.keys(peerDependencies).length;
 
       for (const depName in dependencies) {
         const depVersion = dependencies[depName];
@@ -147,6 +166,18 @@ export async function install(args) {
           totalDependencies += calculateTotalDependencies(
             depInfo,
             depVersion,
+            visited,
+          );
+        }
+      }
+
+      for (const peerDepName in peerDependencies) {
+        const peerDepVersion = peerDependencies[peerDepName];
+        const peerDepInfo = packageInfoList.find((info) => info.name === peerDepName);
+        if (peerDepInfo) {
+          totalDependencies += calculateTotalDependencies(
+            peerDepInfo,
+            peerDepVersion,
             visited,
           );
         }
@@ -220,6 +251,17 @@ export async function install(args) {
           dependencies: installedPackage.dependencies,
         };
       }
+
+      if (installedPackage.peerDependencies) {
+        packageJson.peerDependencies[installedPackage.packageName] =
+          installedPackage.version;
+        lockFileData.peerDependencies[installedPackage.packageName] = {
+          version: installedPackage.version,
+          resolved: installedPackage.resolved,
+          integrity: installedPackage.integrity,
+          dependencies: installedPackage.peerDependencies,
+        };
+      }
     });
 
     await Promise.all(installPromises);
@@ -235,7 +277,6 @@ export async function install(args) {
 
     createLockFile(lockFileData, lockFilePath);
 
-    // Pa139
     const binEntries = packageJson.bin || {};
     if (Object.keys(binEntries).length > 0) {
       const binDir = join(installDir, "node_modules", ".bin");

--- a/commands/install/installPackage.js
+++ b/commands/install/installPackage.js
@@ -21,7 +21,7 @@ export async function installPackage(
   version,
   installDir = process.cwd(),
   postInstallScripts = [],
-  lockFileData = { dependencies: {}, devDependencies: {} },
+  lockFileData = { dependencies: {}, devDependencies: {}, peerDependencies: {} },
   isDevDependency = false,
   currentPackageIndex = 0,
   totalPackages = 0,
@@ -163,6 +163,8 @@ export async function installPackage(
 
   const dependencies =
     metadata.versions[maxSatisfyingVersion].dependencies || {};
+  const peerDependencies =
+    metadata.versions[maxSatisfyingVersion].peerDependencies || {};
 
   const dependencyPromises = Object.entries(dependencies).map(
     async ([depName, depVersion]) => {
@@ -185,7 +187,28 @@ export async function installPackage(
     },
   );
 
-  await Promise.all(dependencyPromises);
+  const peerDependencyPromises = Object.entries(peerDependencies).map(
+    async ([peerDepName, peerDepVersion]) => {
+      await installPackage(
+        spinner,
+        peerDepName,
+        peerDepVersion,
+        installDir,
+        postInstallScripts,
+        lockFileData,
+        isDevDependency,
+        currentPackageIndex,
+        totalPackages,
+        isForce,
+        false,
+      );
+      if (currentPackageIndex < totalPackages) {
+        currentPackageIndex++;
+      }
+    },
+  );
+
+  await Promise.all([...dependencyPromises, ...peerDependencyPromises]);
 
   postInstallScripts.push(packageDir);
 
@@ -196,6 +219,8 @@ export async function installPackage(
       integrity: packageVersion.dist.integrity,
       dependencies:
         Object.keys(dependencies).length > 0 ? dependencies : undefined,
+      peerDependencies:
+        Object.keys(peerDependencies).length > 0 ? peerDependencies : undefined,
     };
   } else {
     lockFileData.dependencies[packageName] = {
@@ -204,10 +229,11 @@ export async function installPackage(
       integrity: packageVersion.dist.integrity,
       dependencies:
         Object.keys(dependencies).length > 0 ? dependencies : undefined,
+      peerDependencies:
+        Object.keys(peerDependencies).length > 0 ? peerDependencies : undefined,
     };
   }
 
-  // Pe142
   const binEntries = packageVersion.bin || {};
   if (Object.keys(binEntries).length > 0) {
     const binDir = join(installDir, "node_modules", ".bin");
@@ -215,7 +241,6 @@ export async function installPackage(
       mkdirSync(binDir, { recursive: true });
     }
 
-    // P474c
     for (const [binName, binPath] of Object.entries(binEntries)) {
       const binFilePath = join(binDir, `${packageName}.pacmx`);
       const binFileContent = `#!/usr/bin/env node\nrequire('${join(
@@ -240,5 +265,6 @@ export async function installPackage(
     resolved: tarballUrl,
     integrity: packageVersion.dist.integrity,
     dependencies,
+    peerDependencies,
   };
 }


### PR DESCRIPTION
Implement peer dependencies handling in the install command and dependencies installation process.

* Update `commands/install/index.js` to handle peer dependencies during the installation process, including fetching and installing peer dependencies, and updating `packageJson` and `lockFileData` to include peer dependencies.
* Modify `commands/install/installPackage.js` to handle peer dependencies, including fetching and installing peer dependencies, and updating `lockFileData` to include peer dependencies.
* Update `commands/install/fetchPackageMetadata.js` to retrieve peer dependencies and handle them in the metadata.

