### PR TITLE
Implement support for .npmrc file and custom registry

### DIFF
--- a/commands/install/index.js
+++ b/commands/install/index.js
@@ -9,6 +9,7 @@ import process from "node:process";
 import chalk from "chalk";
 import logger from "../../lib/logger.js";
 import { fetchAllDependencies } from "./fetchAllDependencies.js";
+import { fetchNpmConfig } from "../../utils/fetchNpmConfig.js";
 
 export async function install(args) {
   const packages = [];

--- a/commands/install/installPackage.js
+++ b/commands/install/installPackage.js
@@ -8,6 +8,7 @@ import { homedir } from "node:os";
 import process from "node:process";
 import chalk from "chalk";
 import logger from "../../lib/logger.js";
+import { fetchNpmConfig } from "../../utils/fetchNpmConfig.js";
 
 const globalCacheDir = join(homedir(), ".pacm-cache");
 

--- a/utils/fetchNpmConfig.js
+++ b/utils/fetchNpmConfig.js
@@ -1,0 +1,45 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function readNpmrcFile() {
+  const projectNpmrcPath = join(process.cwd(), ".npmrc");
+  const homeNpmrcPath = join(homedir(), ".npmrc");
+
+  if (existsSync(projectNpmrcPath)) {
+    return readFileSync(projectNpmrcPath, "utf-8");
+  } else if (existsSync(homeNpmrcPath)) {
+    return readFileSync(homeNpmrcPath, "utf-8");
+  }
+
+  return null;
+}
+
+function readRegistryFromNpmrcOrPackageJson() {
+  const npmrcContent = readNpmrcFile();
+  if (npmrcContent) {
+    const registryMatch = npmrcContent.match(/^registry\s*=\s*(.*)$/m);
+    if (registryMatch) {
+      return registryMatch[1];
+    }
+  }
+
+  const packageJsonPath = join(process.cwd(), "package.json");
+  if (existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+    if (packageJson.publishConfig && packageJson.publishConfig.registry) {
+      return packageJson.publishConfig.registry;
+    }
+  }
+
+  return "https://registry.npmjs.org";
+}
+
+function fetchNpmConfig() {
+  const registry = readRegistryFromNpmrcOrPackageJson();
+  return {
+    registry,
+  };
+}
+
+export { fetchNpmConfig };

--- a/utils/fetchPackageMetadata.js
+++ b/utils/fetchPackageMetadata.js
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { retryOnECONNRESET } from "./retry.js";
 import chalk from "chalk";
+import { fetchNpmConfig } from "./fetchNpmConfig.js";
 
 export async function fetchPackageMetadata(
   packageName,
@@ -9,9 +10,10 @@ export async function fetchPackageMetadata(
   totalPackages,
   isForce,
 ) {
+  const { registry } = fetchNpmConfig();
   spinner.text = `${isForce ? chalk.bgYellow("FORCE") : ""} [${currentPackageIndex}/${totalPackages}] Fetching metadata for ${packageName}`;
   return retryOnECONNRESET(async (packageName) => {
-    const response = await fetch(`https://registry.npmjs.org/${packageName}`);
+    const response = await fetch(`${registry}/${packageName}`);
     if (!response.ok) {
       throw new Error(`Failed to fetch metadata for package ${packageName}`);
     }


### PR DESCRIPTION
Implement support for `.npmrc` file and custom registry.

* Add `utils/fetchNpmConfig.js` to read `.npmrc` file from project root or home directory, read registry from `.npmrc` or `package.json`, and implement fallback options for custom registry issues.
* Modify `utils/fetchPackageMetadata.js` to import `fetchNpmConfig` and use custom registry from `fetchNpmConfig`.
* Modify `commands/install/index.js` to import `fetchNpmConfig`.
* Modify `commands/install/installPackage.js` to import `fetchNpmConfig`.

